### PR TITLE
Bugfix: incorrect expiry calculation for Redis calculated in RedisCac…

### DIFF
--- a/src/Nancy.RapidCache.Redis/RedisCacheStore.cs
+++ b/src/Nancy.RapidCache.Redis/RedisCacheStore.cs
@@ -58,10 +58,8 @@ namespace Nancy.RapidCache.CacheStore
         /// <param name="absoluteExpiration"></param>
         public void Set(string key, NancyContext context, DateTime absoluteExpiration)
         {
-            int length = (absoluteExpiration - DateTime.UtcNow).Seconds;
-            var span = new TimeSpan(0, 0, length);
-
-            if (context.Response is Response && length > 0)
+            var span = absoluteExpiration - DateTime.UtcNow;
+            if (context.Response is Response && span.TotalSeconds > 0)
             {
                 var serialize = new SerializableResponse(context.Response, absoluteExpiration);
                 bool ack = _cache.StringSet(key, Serialize(serialize), expiry: span);


### PR DESCRIPTION
…heStore.cs

TimeSpan.Seconds is incorrect property to use for expiry calculation. TotalSeconds to be used

# Description

Current code limits expiration to 59 seconds

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] My changes generate no new warnings